### PR TITLE
内侧发布：不传sdk参数的尝试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,13 @@ cython_debug/
 
 # osx
 .DS_Store
+
+# pyvenv
+bin
+include
+lib
+pyvenv.cfg
+
+# erispulse
+my_bot
+modules

--- a/src/ErisPulse/__init__.py
+++ b/src/ErisPulse/__init__.py
@@ -37,7 +37,7 @@ sdk.logger.info("SDK已初始化")
 """
 
 import types
-sdk = types.SimpleNamespace()
+# sdk = types.SimpleNamespace()
 import os
 import sys
 from . import util
@@ -46,6 +46,13 @@ from .logger import logger
 from .db import env
 from .mods import mods
 from .adapter import adapter, BaseAdapter, SendDSL
+
+# 添加ModuleFather
+class ModuleFather:
+    sdk = types.SimpleNamespace()
+
+# 外部sdk对象指向ModuleFather
+sdk = ModuleFather.sdk
 
 # 这里不能删，确保windows下的shell能正确显示颜色
 os.system('')
@@ -58,6 +65,9 @@ setattr(sdk, "logger", logger)
 setattr(sdk, "adapter", adapter)
 setattr(sdk, "SendDSL", SendDSL)
 setattr(sdk, "BaseAdapter", BaseAdapter)
+
+# 将ModuleFather链接到外部sdk对象 (实际是同一个sdk)
+setattr(sdk, "ModuleFather", ModuleFather)
 
 # 注册 ErrorHook 并预注册常用错误类型
 raiserr.register("CaughtExternalError"      , doc="捕获的非SDK抛出的异常")
@@ -215,7 +225,9 @@ def init() -> None:
             if not module_status:
                 continue
 
-            moduleMain = moduleObj.Main(sdk)
+            # 这里不再传入sdk，模块继承 sdk.ModuleFather
+            moduleMain = moduleObj.Main()
+
             setattr(moduleMain, "moduleInfo", moduleObj.moduleInfo)
             setattr(sdk, meta_name, moduleMain)
             logger.debug(f"模块 {meta_name} 正在初始化")

--- a/src/ErisPulse/__main__.py
+++ b/src/ErisPulse/__main__.py
@@ -1147,7 +1147,12 @@ def main():
         else:
             shellprint.panel(f"运行脚本: {Shell_Printer.BOLD}{script_path}{Shell_Printer.RESET}", "执行", "info")
             import runpy
-            runpy.run_path(script_path, run_name="__main__")
+
+            # 添加KeyboardInterrupt异常捕捉
+            try:
+                runpy.run_path(script_path, run_name="__main__")
+            except KeyboardInterrupt:
+                shellprint.panel("脚本执行已中断", "中断", "info")
             
     elif args.command == 'origin':
         if args.origin_command == 'add':

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+import types
+
+
+# 添加ModuleFather
+class ModuleFather:
+    sdk = types.SimpleNamespace()
+
+
+# 外部sdk对象指向ModuleFather
+sdk = ModuleFather.sdk
+setattr(sdk, 'ModuleFather', ModuleFather)
+
+sdk.ModuleFather.sdk.aaaaa = 123
+
+print(ModuleFather.sdk.aaaaa)


### PR DESCRIPTION
测试代码：
```python
from ErisPulse import sdk
import asyncio


async def main():
    sdk.init()

    # 启动所有适配器
    await sdk.adapter.startup()

    # 示例：发送日志消息
    sdk.logger.info("机器人已启动")

    sdk.MyModule.print_hello()
    sdk.MyModule2.print_hello()

    # 步骤1: 使用MyModule修改example_var
    sdk.MyModule.modify_sdk()

    # 步骤2: 使用MyModule2读取example_var
    print(sdk.MyModule2.get_example_var())

    # 重复步骤1: 再次修改example_var
    sdk.MyModule.modify_sdk()

    # 重复步骤2: 使用MyModule2读取example_var
    print(sdk.MyModule2.get_example_var())


if __name__ == "__main__":
    asyncio.run(main())
```

以下是此次测试所用的文件：
[files.zip](https://github.com/user-attachments/files/20904494/files.zip)
