### PR TITLE
docs(CLI): 升级 ErisPulse 依赖版本至 2.1.6

### DIFF
--- a/docs/Development/CLI.md
+++ b/docs/Development/CLI.md
@@ -71,7 +71,7 @@ def my_command_register(subparsers: Any, console: Any) -> None:
 [project]
 name = "your-module-name"
 version = "1.0.0"
-dependencies = ["ErisPulse>=1.0.0"]
+dependencies = ["ErisPulse>=2.1.6"]
 
 [project.entry-points."erispulse.cli"]
 "yourcommand" = "my_cli_module:your_command_register"

--- a/examples/example-cli-module/pyproject.toml
+++ b/examples/example-cli-module/pyproject.toml
@@ -8,7 +8,7 @@ license = { file = "LICENSE" }
 authors = [ { name = "yourname", email = "your@mail.com" } ]
 
 dependencies = [
-    "ErisPulse>=1.0.0"
+    "ErisPulse>=2.1.6"
 ]
 
 [project.urls]


### PR DESCRIPTION
将 CLI 文档和示例模块中的 ErisPulse 依赖版本从 1.0.0 升级至 2.1.6