### PR TITLE
fix(run): 修复进程等待逻辑避免重复等待同一进程

### DIFF
--- a/src/ErisPulse/CLI/commands/run.py
+++ b/src/ErisPulse/CLI/commands/run.py
@@ -162,7 +162,12 @@ class RunCommand(Command):
         ))
 
         try:
-            reload_state["process"].wait()
+            while True:
+                proc = reload_state["process"]
+                proc.wait()
+                time.sleep(0.3)
+                if reload_state["process"] is proc:
+                    break
         except KeyboardInterrupt:
             reload_state["process"].terminate()
         finally:


### PR DESCRIPTION
当重新加载状态中的进程发生变化时，原有的 wait() 调用可能会导致程序卡住。
现在通过循环检查确保只等待当前的实际进程，避免无限阻塞的问题。

## 欢迎贡献

感谢您为 ErisPulse 提交 Pull Request！如果您是第一次为 ErisPulse 贡献，请不要担心，我们会帮助您完成整个流程。

在填写以下模板之前，请确保您已经：
- Fork 了本项目到您的 GitHub 账户
- 基于官方的 `Develop/v2` 分支创建了功能分支
- 仔细阅读了 [贡献指南](../../CONTRIBUTING.md)

---

## 提交类型
<!-- 请在适用的选项前打勾 -->
- [ ] 功能新增
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 代码优化
- [ ] 其他

## 变更描述
<!-- 请详细描述本次提交的内容 -->

## 相关 Issue
<!-- 如果有相关的 Issue，请填写链接 -->

## 检查清单
- [ ] 代码符合项目规范
- [ ] 已进行充分测试
- [ ] 文档已更新（如适用）
- [ ] CHANGELOG 已更新（如适用）

## 其他说明
<!-- 其他需要说明的信息 -->